### PR TITLE
Align code in pre tag to the left site of the editor

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -22,6 +22,5 @@ body {
     max-height: 500px;
 }
 .CodeMirror pre {
-    padding-left: 0px;
     line-height: 1.25;
 }

--- a/index.html
+++ b/index.html
@@ -69,14 +69,14 @@
 <body>
     <section id="notebook">
         <textarea id="code">
-            int main( ) {
-  	            int a = 22;
-  	            int c;
-	            int * b;
-  	            b = &a;
-	            a = 12;			  
-  	            c = *b;
-            }					                
+int main( ) {
+    int a = 22;
+    int c;
+    int * b;
+    b = &a;
+    a = 12;
+    c = *b;
+}
 		 </textarea>
         <form>
             <textarea id="console"> Welcome to console. </textarea>


### PR DESCRIPTION
I've noticed that you wanted to align your code to the left in `<pre>` tag :)
That's how it works - every whitespace (and other unusual symbols) that's in your code will be transferred into html page, so unfortunately you have to have that in mind that every unnecessary white space should be removed :(
[The HTML `<pre>` element represents preformatted text which is to be presented exactly as written in the HTML file.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)

Also removed padding from this tag :)

